### PR TITLE
Additional configuration setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,50 @@ Note that ExecTransport does not produce any errors at all, but you can switch i
 <param name="debug" value="1" />
 ```
 
+## Additional Configuration
+For additional configurations, you can set on the XML or the PHP File Configuration. Reference for the additional options are located on the stackify logger repository [Stackify PHP Logger - Configuration Settings](https://github.com/stackify/stackify-api-php#configuration-settings)
+
+### XML Configuration
+- The string should be a JSON String and HTML Encoded (will improve this eventually.)
+```php
+// Sample PHP Config
+$config = array(
+    'Debug' => true,
+    'DebugLogPath' => '/path/to/log.log'
+);
+
+// Converting PHP array to JSON String
+// String: {"Debug":true,"DebugLogPath":"/path/to/log.log"}
+// HTML Encode the JSON String
+// String: {&quot;Debug&quot;:true,&quot;DebugLogPath&quot;:&quot;/path/to/log.log&quot;}
+
+// XML Configuration
+<param name="config" value="{&quot;Debug&quot;:true,&quot;DebugLogPath&quot;:&quot;/path/to/log.log&quot;}" />
+```
+
+### PHP Configuration
+- If using the PHP configuration, basically add the `config` attribute on the `params` under the Stackify Appender settings
+```php
+<?php
+return array(
+    'rootLogger' => array(
+        'appenders' => array('stackifyAppender'),
+    ),
+    'appenders' => array(
+        'stackifyAppender' => array(
+            'class' => '\Stackify\Log\Log4php\Appender',
+            'params' => array(
+                'appName' => 'application-name',
+                'environmentName' => 'environment-name',
+                // Additional configuration
+                'config' => array(
+                    'Debug' => true,
+                    'DebugLogPath' => 'logConfig.log'
+                )
+            )
+        )
+```
+
 ## License
 
 Copyright 2019 Stackify, LLC.

--- a/README.md
+++ b/README.md
@@ -110,9 +110,11 @@ $jsonString = json_encode($config);
 //   - & is replaced with &amp;
 //   - < is replaced with &lt;
 //   - > is replaced with &gt;
-//   - \n is replaced with &#10; or &#xA;
-//   - \r is replaced with &#13; or &#xD;
 // - Encoded String: {&quot;Debug&quot;:true,&quot;DebugLogPath&quot;:&quot;/path/to/log.log&quot;}
+// - Note: In case the string has new line ("\n") or a carriage return ("\r") character, you still need to escape it
+//   - \n should be replaced with &#10; or &#xA;
+//   - \r should be replaced with &#13; or &#xD;
+// - Reference: https://stackoverflow.com/a/29924176/14542233
 $xmlEncode = htmlspecialchars($jsonString, ENT_XML1 | ENT_QUOTES, 'UTF-8');
 
 // 3. Add it as a value on XML Configuration

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ $config = array(
     'Debug' => true,
     'DebugLogPath' => '/path/to/log.log'
 );
-
 // 1. Converting PHP array to JSON String
 // - String: {"Debug":true,"DebugLogPath":"/path/to/log.log"}
+$jsonString = json_encode($config);
 // 2. XML Encode the JSON String
 //   - ' is replaced with &apos;
 //   - " is replaced with &quot;
@@ -113,8 +113,9 @@ $config = array(
 //   - \n is replaced with &#10; or &#xA;
 //   - \r is replaced with &#13; or &#xD;
 // - Encoded String: {&quot;Debug&quot;:true,&quot;DebugLogPath&quot;:&quot;/path/to/log.log&quot;}
+$xmlEncode = htmlspecialchars($jsonString, ENT_XML1 | ENT_QUOTES, 'UTF-8');
 
-// XML Configuration
+// 3. Add it as a value on XML Configuration
 <param name="config" value="{&quot;Debug&quot;:true,&quot;DebugLogPath&quot;:&quot;/path/to/log.log&quot;}" />
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,10 +102,17 @@ $config = array(
     'DebugLogPath' => '/path/to/log.log'
 );
 
-// Converting PHP array to JSON String
-// String: {"Debug":true,"DebugLogPath":"/path/to/log.log"}
-// HTML Encode the JSON String
-// String: {&quot;Debug&quot;:true,&quot;DebugLogPath&quot;:&quot;/path/to/log.log&quot;}
+// 1. Converting PHP array to JSON String
+// - String: {"Debug":true,"DebugLogPath":"/path/to/log.log"}
+// 2. XML Encode the JSON String
+//   - ' is replaced with &apos;
+//   - " is replaced with &quot;
+//   - & is replaced with &amp;
+//   - < is replaced with &lt;
+//   - > is replaced with &gt;
+//   - \n is replaced with &#10; or &#xA;
+//   - \r is replaced with &#13; or &#xD;
+// - Encoded String: {&quot;Debug&quot;:true,&quot;DebugLogPath&quot;:&quot;/path/to/log.log&quot;}
 
 // XML Configuration
 <param name="config" value="{&quot;Debug&quot;:true,&quot;DebugLogPath&quot;:&quot;/path/to/log.log&quot;}" />

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Note that ExecTransport does not produce any errors at all, but you can switch i
 ```
 
 ## Additional Configuration
-For additional configurations, you can set on the XML or the PHP File Configuration. Reference for the additional options are located on the stackify logger repository [Stackify PHP Logger - Configuration Settings](https://github.com/stackify/stackify-api-php#configuration-settings)
+For additional configurations, you can set on the XML or the PHP File Configuration. Reference for the additional options are located on the stackify logger repository [Stackify PHP Logger - Configuration Settings](stackify/stackify-api-php#configuration-settings)
 
 ### XML Configuration
 - The string should be a JSON String and HTML Encoded (will improve this eventually.)

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "library",
     "license": "Apache-2.0",
     "require": {
-        "stackify/logger": "~1.2",
+        "stackify/logger": "~1.3",
         "apache/log4php": "~2.2"
     },
     "autoload": {

--- a/src/Stackify/Log/Log4php/Appender.php
+++ b/src/Stackify/Log/Log4php/Appender.php
@@ -14,71 +14,220 @@ class Appender extends \LoggerAppender
     const MODE_EXEC = 'Exec';
 
     /**
+     * Transport to be used
+     *
      * @var \Stackify\Log\Transport\TransportInterface
      */
-    private $transport;
-    private $appName;
-    private $environmentName;
-    private $apiKey;
-    private $mode;
-    private $port;
-    private $proxy;
-    private $curlPath;
-    private $debug;
-    private $logServerVariables = false;
-
+    protected $transport;
+    /**
+     * Application Name
+     *
+     * @var string
+     */
+    protected $appName;
+    /**
+     * Environment Name
+     *
+     * @var string
+     */
+    protected $environmentName;
+    /**
+     * API Key
+     *
+     * @var string
+     */
+    protected $apiKey;
+    /**
+     * Transport mode
+     *
+     * @var string
+     */
+    protected $mode;
+    /**
+     * Agent Transport Port
+     *
+     * @var integer
+     */
+    protected $port;
+    /**
+     * Curl/Exec Transport Proxy
+     *
+     * @var string
+     */
+    protected $proxy;
+    /**
+     * Exec Transport Curl Path
+     *
+     * @var string
+     */
+    protected $curlPath;
+    /**
+     * Debug Mode
+     *
+     * @var boolean
+     */
+    protected $debug;
+    /**
+     * Log $_SERVER variables
+     *
+     * @var boolean
+     */
+    protected $logServerVariables = false;
+    /**
+     * Addition Custom Configuration
+     *
+     * @var array
+     */
+    protected $config = array();
+    /**
+     * Disable Layout from logging config
+     *
+     * @var boolean
+     */
     protected $requiresLayout = false;
 
-    public function __construct($name = '')
+    /**
+     * Constructor
+     *
+     * @param string $name
+     * @param array  $config
+     */
+    public function __construct($name = '', $config = null)
     {
+        $this->setConfig($config);
         parent::__construct($name);
     }
 
+    /**
+     * Set Application Name
+     *
+     * @param string $appName Application name
+     *
+     * @return void
+     */
     public function setAppName($appName)
     {
         $this->appName = $this->validateNotEmpty('AppName', $appName);
     }
 
+    /**
+     * Set log $_SERVER variables
+     *
+     * @param boolean $logServerVariables Log server variables
+     *
+     * @return void
+     */
     public function setLogServerVariables($logServerVariables)
     {
         $this->logServerVariables = $logServerVariables;
     }
 
+    /**
+     * Set Environtment Name
+     *
+     * @param string $environmentName Environment name
+     *
+     * @return void
+     */
     public function setEnvironmentName($environmentName)
     {
         $this->environmentName = $environmentName;
     }
 
+    /**
+     * Set API Key
+     *
+     * @param string $apiKey API Key
+     *
+     * @return void
+     */
     public function setApiKey($apiKey)
     {
         $this->apiKey = $this->validateNotEmpty('ApiKey', $apiKey);
     }
 
+    /**
+     * Set Transport Mode
+     *
+     * @param string $mode Mode
+     *
+     * @return void
+     */
     public function setMode($mode)
     {
         $this->mode = ucfirst(strtolower($mode));
     }
 
+    /**
+     * Set Agent Transport Port
+     *
+     * @param integer $port Port
+     *
+     * @return void
+     */
     public function setPort($port)
     {
         $this->port = $port;
     }
 
+    /**
+     * Set Curl/Exec Transport Proxy
+     *
+     * @param string $proxy Proxy
+     *
+     * @return void
+     */
     public function setProxy($proxy)
     {
         $this->proxy = $proxy;
     }
 
+    /**
+     * Set Exec Transport Curl Path
+     *
+     * @param string $curlPath Curl path
+     *
+     * @return void
+     */
     public function setCurlPath($curlPath)
     {
         $this->curlPath = $curlPath;
     }
 
+    /**
+     * Set Debug
+     *
+     * @param boolean $debug Debug
+     *
+     * @return void
+     */
     public function setDebug($debug)
     {
         $this->debug = $debug;
     }
 
+    /**
+     * Set Additional Config
+     *
+     * @param string|array $config Config
+     *
+     * @return void
+     */
+    public function setConfig($config)
+    {
+        if (is_string($config)) {
+            $config = @json_decode($config, true);
+        }
+        $this->config = $config;
+    }
+
+    /**
+     * Append logging event
+     *
+     * @param \LoggerLoggingEvent $event Event
+     *
+     * @return void
+     */
     protected function append(\LoggerLoggingEvent $event)
     {
         if (null === $this->transport) {
@@ -90,6 +239,11 @@ class Appender extends \LoggerAppender
         $this->transport->addEntry($logEntry);
     }
 
+    /**
+     * Close logger
+     *
+     * @return void
+     */
     public function close()
     {
         parent::close();
@@ -98,7 +252,15 @@ class Appender extends \LoggerAppender
         }
     }
 
-    private function validateNotEmpty($name, $value)
+    /**
+     * Validate value
+     *
+     * @param string $name  Name
+     * @param string $value Value
+     *
+     * @return void
+     */
+    protected function validateNotEmpty($name, $value)
     {
         $result = trim($value);
         if (empty($result)) {
@@ -108,15 +270,18 @@ class Appender extends \LoggerAppender
     }
 
     /**
+     * Create Transport
+     *
      * @return \Stackify\Log\Transport\TransportInterface
      */
-    private function createTransport()
+    protected function createTransport()
     {
         $options = array(
             'proxy' => $this->proxy,
             'debug' => $this->debug,
             'port'  => $this->port,
             'curlPath' => $this->curlPath,
+            'config' => $this->config
         );
         if (null === $this->mode) {
             $this->mode = self::MODE_AGENTSOCKET;

--- a/src/Stackify/Log/Log4php/Appender.php
+++ b/src/Stackify/Log/Log4php/Appender.php
@@ -89,12 +89,10 @@ class Appender extends \LoggerAppender
     /**
      * Constructor
      *
-     * @param string $name
-     * @param array  $config
+     * @param string $name Appender name
      */
-    public function __construct($name = '', $config = null)
+    public function __construct($name = '')
     {
-        $this->setConfig($config);
         parent::__construct($name);
     }
 


### PR DESCRIPTION
Additional configuration setting for the logger.

Currently for the XML Configuration, it will be purely string as there is no way to embed child nodes for the `params` node. 

For the PHP File configuration, an array can be added.